### PR TITLE
Remove the `https ` link to the project website

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,5 +91,5 @@ layout: default
   <h2>CONSUL Project</h2>
 
   <p>CONSUL is the most complete citizen participation tool for an open, transparent and democratic government.</p>
-  <a href="https://consulproject.org/" target="_blank">Visit CONSUL project site</a>
+  <a href="http://consulproject.org/" target="_blank">Visit CONSUL project site</a>
 </div>


### PR DESCRIPTION
There seems to not be a valid certificate for the project site, thus the link errors in my Firefox.